### PR TITLE
Add vpc and file system support for express component

### DIFF
--- a/serverless.component.yml
+++ b/serverless.component.yml
@@ -1,7 +1,7 @@
-name: express
-version: 1.7.1
-author: eahefnawy
-org: serverlessinc
+name: pingpong-express
+version: 0.0.3
+author: Enaho Murphy
+org: pingpong
 description: Deploys a serverless Express.js application onto AWS Lambda and AWS HTTP API.
 keywords: aws, serverless, express
 repo: https://github.com/serverless-components/express
@@ -9,7 +9,8 @@ license: MIT
 main: ./src
 
 actions:
-  # deploy
+    # deploy
+
   deploy:
     description: Deploy your Express.js application to AWS Lambda, AWS HTTP API and more.
     inputs:
@@ -109,8 +110,30 @@ actions:
         min: 0
         max: 1
 
-  # remove
+      vpc:
+        type: object
+        description: The VPC configuration for your AWS Lambda function
+        required: false
+        keys:
+          - name: securityGroupIds
+            type: array
+            items:
+              - type: string
+          - name: subnetIds
+            type: array
+            items:
+              - type: string
 
+      fileSystemConfig:
+        type: array
+        description: access point access point arn https://docs.aws.amazon.com/lambda/latest/dg/API_FileSystemConfig.html
+        items:
+          - type: object
+            keys:
+              - name: arnName
+                type: string
+              - name: mountPath
+                type: string
   remove:
     description: Removes your Express.js application from AWS Lambda, AWS HTTP API and more
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -271,6 +271,17 @@ const getVpcConfig = (vpcConfig) => {
   };
 };
 
+const getEFS = (fileSystemConfig) => {
+  if (fileSystemConfig == null) {
+    return {};
+  }
+
+  return fileSystemConfig.map(({ arnName, mountPath }) => ({
+    Arn: arnName,
+    LocalMountPath: mountPath,
+  }));
+};
+
 /*
  * Creates a lambda function on aws
  *
@@ -283,6 +294,7 @@ const createLambda = async (instance, inputs, clients, retries = 0) => {
   retries++;
 
   const vpcConfig = getVpcConfig(inputs.vpc);
+  const fileSystemConfig = getEFS(inputs.fileSystemConfig);
 
   const params = {
     FunctionName: instance.state.lambdaName,
@@ -298,6 +310,7 @@ const createLambda = async (instance, inputs, clients, retries = 0) => {
       Variables: inputs.env || {},
     },
     VpcConfig: vpcConfig,
+    FileSystemConfigs: fileSystemConfig,
   };
 
   if (inputs.layers) {


### PR DESCRIPTION
## SUMMARY
- [x]  I created a fork of serverless express component
- [x]  the current version does not have support for efs file system and partial support for vpc configuration
- [x]  we will use a custom component until that is included

## TODO
- [ ] FIx failing test